### PR TITLE
fix: uploaded_at 未記録バグ修正 & ヘルスチェック改善

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -2,7 +2,7 @@
 
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
@@ -60,6 +60,9 @@ async def upload_document(
         # タグ解析
         tags = [t.strip() for t in industry_tags.split(",") if t.strip()]
 
+        # アップロード日時を記録
+        uploaded_at = datetime.now(timezone.utc).isoformat()
+
         # ベクトルDBに登録
         chunk_count = add_chunks(
             doc_id=doc_id,
@@ -67,6 +70,7 @@ async def upload_document(
             filename=file.filename,
             category=category.value,
             industry_tags=tags,
+            uploaded_at=uploaded_at,
         )
 
         return DocumentUploadResponse(

--- a/backend/app/db/vector_store.py
+++ b/backend/app/db/vector_store.py
@@ -30,6 +30,16 @@ def get_collection() -> chromadb.Collection:
     )
 
 
+def check_health() -> dict:
+    """ベクトルDBの接続状態を確認"""
+    try:
+        collection = get_collection()
+        count = collection.count()
+        return {"status": "ok", "document_chunks": count}
+    except Exception as e:
+        return {"status": "error", "detail": str(e)}
+
+
 def add_chunks(
     doc_id: str,
     chunks: list[str],

--- a/backend/app/db/vector_store.py
+++ b/backend/app/db/vector_store.py
@@ -36,6 +36,7 @@ def add_chunks(
     filename: str,
     category: str,
     industry_tags: list[str],
+    uploaded_at: str = "",
 ) -> int:
     """チャンクをベクトルDBに追加"""
     if not chunks:
@@ -52,6 +53,7 @@ def add_chunks(
             "category": category,
             "industry_tags": ",".join(industry_tags),
             "chunk_index": i,
+            "uploaded_at": uploaded_at,
         }
         for i in range(len(chunks))
     ]
@@ -117,6 +119,7 @@ def list_documents() -> list[dict]:
                 "industry_tags": meta.get("industry_tags", "").split(",")
                 if meta.get("industry_tags")
                 else [],
+                "uploaded_at": meta.get("uploaded_at", ""),
                 "chunk_count": 0,
             }
         doc_map[doc_id]["chunk_count"] += 1

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.chat import router as chat_router
 from app.api.documents import router as documents_router
 from app.core.config import settings
+from app.db.vector_store import check_health as check_vector_store_health
 
 app = FastAPI(
     title="Sales RAG Copilot API",
@@ -27,4 +28,13 @@ app.include_router(chat_router)
 
 @app.get("/api/health")
 async def health():
-    return {"status": "ok", "service": "sales-rag-copilot"}
+    vector_store = check_vector_store_health()
+    overall_status = "ok" if vector_store["status"] == "ok" else "degraded"
+    return {
+        "status": overall_status,
+        "service": "sales-rag-copilot",
+        "version": app.version,
+        "components": {
+            "vector_store": vector_store,
+        },
+    }


### PR DESCRIPTION
## Summary

- 資料アップロード時に `uploaded_at` (ISO 8601形式) がベクトルDBのメタデータに記録されるように修正。これにより、フロントエンドで資料のアップロード日時を正しく表示可能になります。
- `/api/health` エンドポイントにベクトルDB (ChromaDB) の接続確認を追加。DB接続に問題がある場合はステータスを `degraded` として返し、運用監視に役立てられるようにしました。

## 変更内容

### コミット1: `uploaded_at` バグ修正
- `backend/app/db/vector_store.py`: `add_chunks()` に `uploaded_at` パラメータを追加し、メタデータに記録
- `backend/app/db/vector_store.py`: `list_documents()` で `uploaded_at` を返却に含める
- `backend/app/api/documents.py`: `upload_document()` で現在日時 (UTC) を生成し `add_chunks()` に渡す

### コミット2: ヘルスチェック改善
- `backend/app/db/vector_store.py`: `check_health()` 関数を追加（コレクションのチャンク数を返却）
- `backend/app/main.py`: `/api/health` で `check_health()` を呼び出し、DB接続状態とバージョン情報を含むレスポンスに拡張

## Test plan

- [ ] 資料をアップロードし、`GET /api/documents/` で `uploaded_at` が ISO 8601 形式で返却されることを確認
- [ ] `GET /api/health` でレスポンスに `components.vector_store.status` が含まれることを確認
- [ ] ChromaDB 未接続時に `/api/health` が `{"status": "degraded"}` を返すことを確認

Closes #4