### PR TITLE
feat: ロギング追加・入力バリデーション強化・テスト追加・ChromaDB API移行

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,10 @@
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_MODEL=gpt-4o-mini
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIMENSION=1536
 CHUNK_SIZE=500
 CHUNK_OVERLAP=50
 TOP_K=5
 CORS_ORIGINS=http://localhost:3000
+CHROMA_PERSIST_DIR=./chroma_data
+UPLOAD_DIR=./uploads

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -1,9 +1,13 @@
 """チャットAPI"""
 
+import logging
+
 from fastapi import APIRouter, HTTPException
 
 from app.core.rag import generate_rag_response
 from app.models.schemas import ChatRequest, ChatResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/chat", tags=["chat"])
 
@@ -11,11 +15,24 @@ router = APIRouter(prefix="/api/chat", tags=["chat"])
 @router.post("/", response_model=ChatResponse)
 async def chat(request: ChatRequest):
     """質問に対してRAG回答を生成"""
+    # バリデーションはスキーマ側で実施済み。APIレベルでも空文字を弾く
     if not request.query.strip():
         raise HTTPException(status_code=400, detail="質問を入力してください")
 
+    logger.info(
+        "チャットリクエスト受信: query_length=%d, output_format=%s, category_filter=%s",
+        len(request.query),
+        request.output_format.value,
+        request.category_filter.value if request.category_filter else "なし",
+    )
+
     try:
         response = generate_rag_response(request)
+        logger.info(
+            "チャットレスポンス生成完了: sources_count=%d",
+            len(response.sources),
+        )
         return response
     except Exception as e:
+        logger.error("チャット回答生成エラー: %s", str(e), exc_info=True)
         raise HTTPException(status_code=500, detail=f"回答生成エラー: {str(e)}")

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,5 +1,6 @@
 """資料管理API"""
 
+import logging
 import os
 import uuid
 from datetime import datetime, timezone
@@ -17,9 +18,13 @@ from app.models.schemas import (
     DocumentUploadResponse,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/documents", tags=["documents"])
 
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".doc", ".pptx", ".txt", ".md"}
+MAX_FILE_SIZE_MB = 50
+MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
 
 
 @router.post("/upload", response_model=DocumentUploadResponse)
@@ -45,6 +50,21 @@ async def upload_document(
     file_path = os.path.join(settings.upload_dir, f"{doc_id}{ext}")
 
     content = await file.read()
+
+    # ファイルサイズチェック
+    if len(content) > MAX_FILE_SIZE_BYTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"ファイルサイズが上限 ({MAX_FILE_SIZE_MB}MB) を超えています",
+        )
+
+    logger.info(
+        "ファイルアップロード開始: filename=%s, size=%d bytes, category=%s",
+        file.filename,
+        len(content),
+        category.value,
+    )
+
     with open(file_path, "wb") as f:
         f.write(content)
 
@@ -73,6 +93,12 @@ async def upload_document(
             uploaded_at=uploaded_at,
         )
 
+        logger.info(
+            "ファイルアップロード完了: doc_id=%s, filename=%s, chunk_count=%d",
+            doc_id,
+            file.filename,
+            chunk_count,
+        )
         return DocumentUploadResponse(
             id=doc_id,
             filename=file.filename,
@@ -85,13 +111,21 @@ async def upload_document(
         # 失敗時はファイルをクリーンアップ
         if os.path.exists(file_path):
             os.remove(file_path)
+        logger.error(
+            "ファイルアップロードエラー: filename=%s, error=%s",
+            file.filename,
+            str(e),
+            exc_info=True,
+        )
         raise HTTPException(status_code=500, detail=f"処理エラー: {str(e)}")
 
 
 @router.get("/", response_model=DocumentListResponse)
 async def get_documents():
     """登録済み資料一覧を取得"""
+    logger.debug("ドキュメント一覧取得リクエスト")
     docs = list_documents()
+    logger.info("ドキュメント一覧取得: %d 件", len(docs))
     return DocumentListResponse(
         documents=[DocumentMetadata(**doc) for doc in docs],
         total=len(docs),
@@ -101,5 +135,7 @@ async def get_documents():
 @router.delete("/{doc_id}")
 async def remove_document(doc_id: str):
     """資料を削除"""
+    logger.info("ドキュメント削除リクエスト: doc_id=%s", doc_id)
     delete_document(doc_id)
+    logger.info("ドキュメント削除完了: doc_id=%s", doc_id)
     return {"message": "削除しました", "doc_id": doc_id}

--- a/backend/app/core/embeddings.py
+++ b/backend/app/core/embeddings.py
@@ -1,8 +1,12 @@
 """OpenAI Embedding生成モジュール"""
 
+import logging
+
 from openai import OpenAI
 
 from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 _client: OpenAI | None = None
 
@@ -16,14 +20,21 @@ def _get_client() -> OpenAI:
 
 def generate_embeddings(texts: list[str]) -> list[list[float]]:
     """テキストリストからEmbeddingベクトルを生成"""
+    if not texts:
+        logger.warning("generate_embeddings: 空のテキストリストが渡されました")
+        return []
+    logger.debug("Embedding生成開始: texts_count=%d, model=%s", len(texts), settings.openai_embedding_model)
     client = _get_client()
     response = client.embeddings.create(
         model=settings.openai_embedding_model,
         input=texts,
     )
+    logger.debug("Embedding生成完了: embeddings_count=%d", len(response.data))
     return [item.embedding for item in response.data]
 
 
 def generate_embedding(text: str) -> list[float]:
     """単一テキストからEmbeddingベクトルを生成"""
+    if not text.strip():
+        raise ValueError("Embeddingを生成するテキストが空です")
     return generate_embeddings([text])[0]

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -1,6 +1,9 @@
 """テキスト抽出モジュール: PDF, DOCX, PPTX, TXT, Markdown に対応"""
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 def extract_text(file_path: str) -> str:
@@ -10,13 +13,16 @@ def extract_text(file_path: str) -> str:
         ".docx": _extract_docx,
         ".doc": _extract_docx,
         ".pptx": _extract_pptx,
-        ".txt": _extract_text,
-        ".md": _extract_text,
+        ".txt": _extract_plain_text,
+        ".md": _extract_plain_text,
     }
     extractor = extractors.get(ext)
     if extractor is None:
         raise ValueError(f"Unsupported file type: {ext}")
-    return extractor(file_path)
+    logger.info("テキスト抽出開始: file_path=%s, ext=%s", file_path, ext)
+    text = extractor(file_path)
+    logger.info("テキスト抽出完了: file_path=%s, text_length=%d", file_path, len(text))
+    return text
 
 
 def _extract_pdf(file_path: str) -> str:
@@ -53,6 +59,19 @@ def _extract_pptx(file_path: str) -> str:
     return "\n".join(texts)
 
 
-def _extract_text(file_path: str) -> str:
-    with open(file_path, "r", encoding="utf-8") as f:
-        return f.read()
+def _extract_plain_text(file_path: str) -> str:
+    """テキスト・Markdownファイルを読み込む（エンコーディング自動検出）"""
+    encodings = ["utf-8", "utf-8-sig", "shift-jis", "euc-jp", "latin-1"]
+    for encoding in encodings:
+        try:
+            with open(file_path, "r", encoding=encoding) as f:
+                content = f.read()
+            logger.debug("テキストファイル読み込み成功: encoding=%s, file=%s", encoding, file_path)
+            return content
+        except UnicodeDecodeError:
+            logger.debug("エンコーディング %s での読み込み失敗。次を試行: %s", encoding, file_path)
+            continue
+    # フォールバック: バイナリ読み込みで無効文字を置換
+    logger.warning("全エンコーディング失敗。バイナリモードで読み込み: %s", file_path)
+    with open(file_path, "rb") as f:
+        return f.read().decode("utf-8", errors="replace")

--- a/backend/app/core/rag.py
+++ b/backend/app/core/rag.py
@@ -1,10 +1,14 @@
 """RAG回答生成モジュール"""
 
+import logging
+
 from openai import OpenAI
 
 from app.core.config import settings
 from app.db.vector_store import search
 from app.models.schemas import ChatRequest, ChatResponse, OutputFormat, SourceReference
+
+logger = logging.getLogger(__name__)
 
 _client: OpenAI | None = None
 
@@ -50,6 +54,7 @@ def generate_rag_response(request: ChatRequest) -> ChatResponse:
     """RAGパイプライン: 検索 → コンテキスト構築 → LLM回答生成"""
 
     # 1. ベクトル検索
+    logger.info("RAGパイプライン開始: query='%s...'", request.query[:50])
     results = search(
         query=request.query,
         category_filter=request.category_filter.value if request.category_filter else None,
@@ -63,8 +68,16 @@ def generate_rag_response(request: ChatRequest) -> ChatResponse:
     metadatas = results.get("metadatas", [[]])[0]
     distances = results.get("distances", [[]])[0]
 
+    logger.info("ベクトル検索完了: %d 件の参考資料を取得", len(documents))
+
     for i, (doc, meta, dist) in enumerate(zip(documents, metadatas, distances)):
         relevance_score = max(0, 1 - dist)  # cosine距離をスコアに変換
+        logger.debug(
+            "参考資料 %d: filename=%s, relevance_score=%.3f",
+            i + 1,
+            meta.get("filename", "不明"),
+            relevance_score,
+        )
         context_parts.append(
             f"【参考資料{i + 1}: {meta['filename']}（{meta['category']}）】\n{doc}"
         )
@@ -79,6 +92,9 @@ def generate_rag_response(request: ChatRequest) -> ChatResponse:
 
     context = "\n\n".join(context_parts)
 
+    if not context:
+        logger.warning("関連する参考資料が見つかりませんでした: query='%s...'", request.query[:50])
+
     # 3. LLM回答生成
     format_instruction = FORMAT_INSTRUCTIONS[request.output_format]
     system_message = SYSTEM_PROMPT.format(format_instruction=format_instruction)
@@ -90,6 +106,7 @@ def generate_rag_response(request: ChatRequest) -> ChatResponse:
 {context if context else "（関連する資料が見つかりませんでした）"}
 """
 
+    logger.info("LLM回答生成開始: model=%s, output_format=%s", settings.openai_model, request.output_format.value)
     client = _get_client()
     response = client.chat.completions.create(
         model=settings.openai_model,
@@ -102,6 +119,11 @@ def generate_rag_response(request: ChatRequest) -> ChatResponse:
     )
 
     answer = response.choices[0].message.content or "回答を生成できませんでした。"
+    logger.info(
+        "LLM回答生成完了: answer_length=%d, usage=%s",
+        len(answer),
+        response.usage,
+    )
 
     return ChatResponse(
         answer=answer,

--- a/backend/app/db/vector_store.py
+++ b/backend/app/db/vector_store.py
@@ -1,10 +1,13 @@
 """ChromaDB ベクトルストア"""
 
+import logging
+
 import chromadb
-from chromadb.config import Settings as ChromaSettings
 
 from app.core.config import settings
 from app.core.embeddings import generate_embedding, generate_embeddings
+
+logger = logging.getLogger(__name__)
 
 _client: chromadb.ClientAPI | None = None
 COLLECTION_NAME = "sales_documents"
@@ -13,11 +16,9 @@ COLLECTION_NAME = "sales_documents"
 def _get_client() -> chromadb.ClientAPI:
     global _client
     if _client is None:
-        _client = chromadb.Client(
-            ChromaSettings(
-                persist_directory=settings.chroma_persist_dir,
-                anonymized_telemetry=False,
-            )
+        logger.info("ChromaDB クライアント初期化: persist_dir=%s", settings.chroma_persist_dir)
+        _client = chromadb.PersistentClient(
+            path=settings.chroma_persist_dir,
         )
     return _client
 
@@ -35,8 +36,10 @@ def check_health() -> dict:
     try:
         collection = get_collection()
         count = collection.count()
+        logger.debug("ChromaDB ヘルスチェック OK: document_chunks=%d", count)
         return {"status": "ok", "document_chunks": count}
     except Exception as e:
+        logger.error("ChromaDB ヘルスチェック失敗: %s", str(e), exc_info=True)
         return {"status": "error", "detail": str(e)}
 
 
@@ -50,8 +53,10 @@ def add_chunks(
 ) -> int:
     """チャンクをベクトルDBに追加"""
     if not chunks:
+        logger.warning("add_chunks: チャンクが空です。doc_id=%s", doc_id)
         return 0
 
+    logger.info("チャンク追加開始: doc_id=%s, filename=%s, chunk_count=%d", doc_id, filename, len(chunks))
     collection = get_collection()
     embeddings = generate_embeddings(chunks)
 
@@ -74,6 +79,7 @@ def add_chunks(
         documents=chunks,
         metadatas=metadatas,
     )
+    logger.info("チャンク追加完了: doc_id=%s, chunk_count=%d", doc_id, len(chunks))
     return len(chunks)
 
 
@@ -84,6 +90,13 @@ def search(
     industry_filter: str | None = None,
 ) -> dict:
     """ベクトル類似度検索"""
+    logger.info(
+        "ベクトル検索開始: query='%s...', top_k=%s, category_filter=%s, industry_filter=%s",
+        query[:30],
+        top_k or settings.top_k,
+        category_filter,
+        industry_filter,
+    )
     collection = get_collection()
     query_embedding = generate_embedding(query)
 
@@ -106,11 +119,15 @@ def search(
 
 def delete_document(doc_id: str) -> None:
     """ドキュメントの全チャンクを削除"""
+    logger.info("ドキュメント削除開始: doc_id=%s", doc_id)
     collection = get_collection()
     # doc_idに一致するチャンクを検索して削除
     results = collection.get(where={"doc_id": doc_id})
     if results["ids"]:
         collection.delete(ids=results["ids"])
+        logger.info("ドキュメント削除完了: doc_id=%s, deleted_chunks=%d", doc_id, len(results["ids"]))
+    else:
+        logger.warning("ドキュメント削除: 対象チャンクが見つかりません。doc_id=%s", doc_id)
 
 
 def list_documents() -> list[dict]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
 """Sales RAG Copilot - FastAPI Backend"""
 
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -7,6 +9,12 @@ from app.api.chat import router as chat_router
 from app.api.documents import router as documents_router
 from app.core.config import settings
 from app.db.vector_store import check_health as check_vector_store_health
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="Sales RAG Copilot API",
@@ -25,11 +33,15 @@ app.add_middleware(
 app.include_router(documents_router)
 app.include_router(chat_router)
 
+logger.info("Sales RAG Copilot API 起動完了 (version=%s)", app.version)
+
 
 @app.get("/api/health")
 async def health():
+    logger.debug("ヘルスチェックリクエスト受信")
     vector_store = check_vector_store_health()
     overall_status = "ok" if vector_store["status"] == "ok" else "degraded"
+    logger.info("ヘルスチェック結果: status=%s", overall_status)
     return {
         "status": overall_status,
         "service": "sales-rag-copilot",

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,7 +1,6 @@
-from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class OutputFormat(str, Enum):
@@ -41,10 +40,17 @@ class DocumentListResponse(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    query: str
+    query: str = Field(..., min_length=1, max_length=2000, description="質問文（最大2000文字）")
     output_format: OutputFormat = OutputFormat.bullet
     category_filter: CategoryType | None = None
     industry_filter: str | None = None
+
+    @field_validator("query")
+    @classmethod
+    def query_must_not_be_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("質問文は空白のみでは無効です")
+        return v.strip()
 
 
 class SourceReference(BaseModel):

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,6 @@ pypdf2==3.0.1
 tiktoken==0.8.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
+pytest==8.3.4
+pytest-asyncio==0.25.0
+httpx==0.28.1

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -1,0 +1,79 @@
+"""chunker モジュールのユニットテスト"""
+
+import pytest
+
+from app.core.chunker import _split_into_sentences, chunk_text
+
+
+class TestSplitIntoSentences:
+    """_split_into_sentences のテスト"""
+
+    def test_japanese_sentences(self):
+        """日本語の句点で分割できる"""
+        text = "これはテストです。次の文です。最後の文です。"
+        sentences = _split_into_sentences(text)
+        assert len(sentences) >= 2
+        assert any("テスト" in s for s in sentences)
+
+    def test_newline_split(self):
+        """改行で分割できる"""
+        text = "行1\n行2\n行3"
+        sentences = _split_into_sentences(text)
+        assert len(sentences) >= 2
+
+    def test_empty_text(self):
+        """空文字列の場合は空リストを返す"""
+        sentences = _split_into_sentences("")
+        assert sentences == []
+
+    def test_single_sentence(self):
+        """句点なしの場合も単一要素のリストを返す"""
+        text = "句点のない一文"
+        sentences = _split_into_sentences(text)
+        assert len(sentences) == 1
+        assert sentences[0] == "句点のない一文"
+
+    def test_english_sentences(self):
+        """英語のピリオドで分割できる"""
+        text = "This is a test. This is another sentence."
+        sentences = _split_into_sentences(text)
+        assert len(sentences) >= 1
+
+
+class TestChunkText:
+    """chunk_text のテスト"""
+
+    def test_short_text_returns_single_chunk(self):
+        """短いテキストは1チャンクになる"""
+        text = "短いテキストです。"
+        chunks = chunk_text(text)
+        assert len(chunks) == 1
+        assert "短いテキスト" in chunks[0]
+
+    def test_long_text_splits_into_multiple_chunks(self):
+        """chunk_size を超える長いテキストは複数チャンクに分割される"""
+        # 500文字を超えるテキストを生成
+        long_text = "これはテストの文章です。" * 50  # 約600文字
+        chunks = chunk_text(long_text)
+        assert len(chunks) > 1
+
+    def test_empty_text_returns_empty_list(self):
+        """空文字列は空リストを返す"""
+        chunks = chunk_text("")
+        assert chunks == []
+
+    def test_chunks_contain_text(self):
+        """各チャンクに元のテキストの一部が含まれる"""
+        text = "テスト文1です。テスト文2です。テスト文3です。"
+        chunks = chunk_text(text)
+        combined = "".join(chunks)
+        # 元のテキストの主要な内容が保持されている
+        assert "テスト文" in combined
+
+    def test_chunk_returns_list_of_strings(self):
+        """返り値が文字列リストである"""
+        text = "テストです。"
+        chunks = chunk_text(text)
+        assert isinstance(chunks, list)
+        for chunk in chunks:
+            assert isinstance(chunk, str)

--- a/backend/tests/test_extractor.py
+++ b/backend/tests/test_extractor.py
@@ -1,0 +1,76 @@
+"""extractor モジュールのユニットテスト"""
+
+import os
+import tempfile
+
+import pytest
+
+from app.core.extractor import _extract_plain_text, extract_text
+
+
+class TestExtractPlainText:
+    """_extract_plain_text のテスト"""
+
+    def test_utf8_file(self, tmp_path):
+        """UTF-8エンコードのファイルを正常に読み込む"""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("UTF-8テキストです。", encoding="utf-8")
+        result = _extract_plain_text(str(test_file))
+        assert result == "UTF-8テキストです。"
+
+    def test_utf8_bom_file(self, tmp_path):
+        """UTF-8 BOMエンコードのファイルを正常に読み込む"""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("BOM付きテキストです。", encoding="utf-8-sig")
+        result = _extract_plain_text(str(test_file))
+        assert "BOM付きテキストです。" in result
+
+    def test_shift_jis_file(self, tmp_path):
+        """Shift-JISエンコードのファイルを正常に読み込む"""
+        test_file = tmp_path / "test.txt"
+        test_file.write_bytes("Shift-JISテキスト".encode("shift-jis"))
+        result = _extract_plain_text(str(test_file))
+        assert "Shift-JIS" in result or len(result) > 0
+
+    def test_empty_file(self, tmp_path):
+        """空ファイルは空文字列を返す"""
+        test_file = tmp_path / "empty.txt"
+        test_file.write_text("", encoding="utf-8")
+        result = _extract_plain_text(str(test_file))
+        assert result == ""
+
+    def test_multiline_file(self, tmp_path):
+        """複数行のファイルを正常に読み込む"""
+        test_file = tmp_path / "multi.txt"
+        content = "行1\n行2\n行3\n"
+        test_file.write_text(content, encoding="utf-8")
+        result = _extract_plain_text(str(test_file))
+        assert "行1" in result
+        assert "行2" in result
+        assert "行3" in result
+
+
+class TestExtractText:
+    """extract_text のテスト"""
+
+    def test_txt_file(self, tmp_path):
+        """TXTファイルのテキスト抽出"""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("テキストファイルです。", encoding="utf-8")
+        result = extract_text(str(test_file))
+        assert "テキストファイルです" in result
+
+    def test_md_file(self, tmp_path):
+        """Markdownファイルのテキスト抽出"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# タイトル\n本文です。", encoding="utf-8")
+        result = extract_text(str(test_file))
+        assert "タイトル" in result
+        assert "本文" in result
+
+    def test_unsupported_extension_raises_error(self, tmp_path):
+        """未対応の拡張子はValueErrorを発生させる"""
+        test_file = tmp_path / "test.xyz"
+        test_file.write_text("テスト", encoding="utf-8")
+        with pytest.raises(ValueError, match="Unsupported file type"):
+            extract_text(str(test_file))

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,0 +1,118 @@
+"""schemas モジュールのユニットテスト"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.schemas import (
+    CategoryType,
+    ChatRequest,
+    ChatResponse,
+    DocumentMetadata,
+    DocumentUploadResponse,
+    OutputFormat,
+    SourceReference,
+)
+
+
+class TestChatRequest:
+    """ChatRequest バリデーションのテスト"""
+
+    def test_valid_request(self):
+        """正常なリクエストが作成できる"""
+        req = ChatRequest(query="競合他社との比較を教えてください")
+        assert req.query == "競合他社との比較を教えてください"
+        assert req.output_format == OutputFormat.bullet
+
+    def test_query_stripped_of_whitespace(self):
+        """クエリの前後の空白が除去される"""
+        req = ChatRequest(query="  テスト質問  ")
+        assert req.query == "テスト質問"
+
+    def test_empty_query_raises_validation_error(self):
+        """空のクエリはバリデーションエラーになる"""
+        with pytest.raises(ValidationError):
+            ChatRequest(query="")
+
+    def test_blank_query_raises_validation_error(self):
+        """空白のみのクエリはバリデーションエラーになる"""
+        with pytest.raises(ValidationError):
+            ChatRequest(query="   ")
+
+    def test_query_too_long_raises_validation_error(self):
+        """2000文字超のクエリはバリデーションエラーになる"""
+        long_query = "あ" * 2001
+        with pytest.raises(ValidationError):
+            ChatRequest(query=long_query)
+
+    def test_query_max_length_is_accepted(self):
+        """2000文字のクエリは受け付ける"""
+        max_query = "あ" * 2000
+        req = ChatRequest(query=max_query)
+        assert len(req.query) == 2000
+
+    def test_output_format_options(self):
+        """各出力フォーマットが正常に設定できる"""
+        for fmt in OutputFormat:
+            req = ChatRequest(query="テスト", output_format=fmt)
+            assert req.output_format == fmt
+
+    def test_category_filter_optional(self):
+        """category_filterはオプションである"""
+        req = ChatRequest(query="テスト", category_filter=None)
+        assert req.category_filter is None
+
+    def test_category_filter_valid_value(self):
+        """有効なcategory_filterが設定できる"""
+        req = ChatRequest(query="テスト", category_filter=CategoryType.proposal)
+        assert req.category_filter == CategoryType.proposal
+
+    def test_industry_filter_optional(self):
+        """industry_filterはオプションである"""
+        req = ChatRequest(query="テスト", industry_filter=None)
+        assert req.industry_filter is None
+
+
+class TestDocumentMetadata:
+    """DocumentMetadata のテスト"""
+
+    def test_valid_metadata(self):
+        """正常なメタデータが作成できる"""
+        meta = DocumentMetadata(
+            id="test-id",
+            filename="test.pdf",
+            category=CategoryType.proposal,
+        )
+        assert meta.id == "test-id"
+        assert meta.filename == "test.pdf"
+        assert meta.chunk_count == 0
+
+    def test_default_values(self):
+        """デフォルト値が正しく設定される"""
+        meta = DocumentMetadata(id="id", filename="file.pdf")
+        assert meta.category == CategoryType.other
+        assert meta.industry_tags == []
+        assert meta.uploaded_at == ""
+        assert meta.chunk_count == 0
+
+
+class TestOutputFormat:
+    """OutputFormat Enum のテスト"""
+
+    def test_all_formats_exist(self):
+        """すべての出力フォーマットが存在する"""
+        assert OutputFormat.bullet == "bullet"
+        assert OutputFormat.summary == "summary"
+        assert OutputFormat.proposal_memo == "proposal_memo"
+
+
+class TestCategoryType:
+    """CategoryType Enum のテスト"""
+
+    def test_all_categories_exist(self):
+        """すべてのカテゴリが存在する"""
+        assert CategoryType.proposal == "提案書"
+        assert CategoryType.case_study == "導入事例"
+        assert CategoryType.product == "商品資料"
+        assert CategoryType.competitor == "競合比較"
+        assert CategoryType.meeting_note == "商談メモ"
+        assert CategoryType.other == "その他"


### PR DESCRIPTION
## 概要

Issue #9 で特定した改善点をすべて対応しました。

## 変更内容

### ロギング追加
- `main.py`, `api/chat.py`, `api/documents.py`, `core/rag.py`, `core/embeddings.py`, `core/extractor.py`, `db/vector_store.py` に構造化ログを追加
- 各処理の開始・完了・エラーをログ出力するようにした

### 入力バリデーション強化
- `ChatRequest.query` に `max_length=2000` バリデーションを追加（LLMトークン制限対策）
- `query_must_not_be_blank` バリデーターで空白文字のみの入力を弾く
- ドキュメントアップロードにファイルサイズ上限（50MB）チェックを追加

### テキスト抽出の改善
- `_extract_text` をエンコーディング自動検出対応に改善
  - UTF-8 → UTF-8 BOM → Shift-JIS → EUC-JP → Latin-1 の順で試行
  - すべて失敗した場合はバイナリ読み込みで無効文字を置換

### ChromaDB API移行
- 非推奨の `chromadb.Client()` を `chromadb.PersistentClient()` に移行
- `ChromaSettings` の不要なインポートを除去

### 環境変数設定の補完
- `.env.example` に `CHROMA_PERSIST_DIR`, `UPLOAD_DIR`, `EMBEDDING_DIMENSION` を追加

### テスト追加
- `tests/test_chunker.py`: チャンク分割ロジックのユニットテスト
- `tests/test_extractor.py`: テキスト抽出のユニットテスト（エンコーディング含む）
- `tests/test_schemas.py`: Pydanticスキーマのバリデーションテスト
- `requirements.txt` に `pytest`, `pytest-asyncio`, `httpx` を追加
- `pytest.ini` を追加

## テスト確認項目

- [ ] `pytest backend/tests/` でユニットテストが通る
- [ ] ドキュメントアップロードAPI で 50MB 超のファイルが 400 エラーになる
- [ ] 2001文字以上のクエリで 422 エラーになる
- [ ] ログが適切に出力される

Closes #9