### PR TITLE
chore: GitHub Actions CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        working-directory: backend
+        run: pytest tests/ -v
+        env:
+          OPENAI_API_KEY: "sk-dummy-key-for-testing"
+          CHROMA_HOST: "localhost"
+          CHROMA_PORT: "8000"


### PR DESCRIPTION
## 概要

Issue #11 に対応するため、GitHub Actions CI ワークフローを追加します。

## 変更内容

- `.github/workflows/ci.yml` を新規作成
- push/pull_request トリガーでバックエンドテストを自動実行
- Python 3.11 環境でテストを実行
- `backend/requirements.txt` の依存関係をインストール
- `pytest tests/ -v` でテストを実行 (pytest.ini の設定に従う)
- pip キャッシュを活用してCI実行時間を短縮

## テスト対象

- `test_schemas.py` - Pydanticスキーマのバリデーションテスト
- `test_chunker.py` - チャンキング処理のテスト
- `test_extractor.py` - テキスト抽出のテスト

## 関連 Issue

Closes #11