### PR TITLE
feat: エラーメッセージのサニタイズとOpenAI APIタイムアウト設定の追加

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -35,4 +35,4 @@ async def chat(request: ChatRequest):
         return response
     except Exception as e:
         logger.error("チャット回答生成エラー: %s", str(e), exc_info=True)
-        raise HTTPException(status_code=500, detail=f"回答生成エラー: {str(e)}")
+        raise HTTPException(status_code=500, detail="回答生成中にエラーが発生しました。しばらく経ってから再度お試しください。")

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -117,7 +117,7 @@ async def upload_document(
             str(e),
             exc_info=True,
         )
-        raise HTTPException(status_code=500, detail=f"処理エラー: {str(e)}")
+        raise HTTPException(status_code=500, detail="ファイル処理中にエラーが発生しました。ファイルの形式をご確認のうえ再度お試しください。")
 
 
 @router.get("/", response_model=DocumentListResponse)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000"
     chroma_persist_dir: str = "./chroma_data"
     upload_dir: str = "./uploads"
+    openai_timeout: float = 30.0
+    openai_connect_timeout: float = 10.0
 
     class Config:
         env_file = ".env"

--- a/backend/app/core/rag.py
+++ b/backend/app/core/rag.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import httpx
 from openai import OpenAI
 
 from app.core.config import settings
@@ -16,7 +17,10 @@ _client: OpenAI | None = None
 def _get_client() -> OpenAI:
     global _client
     if _client is None:
-        _client = OpenAI(api_key=settings.openai_api_key)
+        _client = OpenAI(
+            api_key=settings.openai_api_key,
+            timeout=httpx.Timeout(settings.openai_timeout, connect=settings.openai_connect_timeout),
+        )
     return _client
 
 

--- a/backend/tests/test_chat_router.py
+++ b/backend/tests/test_chat_router.py
@@ -1,0 +1,53 @@
+"""chat ルーターのユニットテスト"""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.chat import router
+
+
+def _create_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestChatErrorSanitization:
+    """チャットAPIエラーメッセージサニタイズのテスト"""
+
+    @patch("app.api.chat.generate_rag_response", side_effect=RuntimeError("OpenAI API key invalid"))
+    def test_internal_error_details_not_leaked(self, mock_rag):
+        """内部エラー詳細がレスポンスに含まれないことを検証"""
+        client = _create_client()
+        response = client.post(
+            "/api/chat/",
+            json={"query": "テスト質問"},
+        )
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert "OpenAI API key invalid" not in detail
+        assert "回答生成中にエラーが発生しました" in detail
+
+    @patch("app.api.chat.generate_rag_response", side_effect=ValueError("secret db connection string"))
+    def test_sanitized_message_for_various_exceptions(self, mock_rag):
+        """さまざまな例外でもサニタイズされたメッセージが返される"""
+        client = _create_client()
+        response = client.post(
+            "/api/chat/",
+            json={"query": "テスト質問"},
+        )
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert "secret db connection string" not in detail
+        assert "しばらく経ってから再度お試しください" in detail
+
+    def test_empty_query_returns_400(self):
+        """空のクエリで400を返す"""
+        client = _create_client()
+        response = client.post(
+            "/api/chat/",
+            json={"query": "   "},
+        )
+        assert response.status_code in (400, 422)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,23 @@
+"""config モジュールのユニットテスト"""
+
+from app.core.config import Settings
+
+
+class TestTimeoutSettings:
+    """タイムアウト設定のテスト"""
+
+    def test_default_openai_timeout(self):
+        """デフォルトのOpenAIタイムアウトが30秒であること"""
+        s = Settings()
+        assert s.openai_timeout == 30.0
+
+    def test_default_openai_connect_timeout(self):
+        """デフォルトのOpenAI接続タイムアウトが10秒であること"""
+        s = Settings()
+        assert s.openai_connect_timeout == 10.0
+
+    def test_timeout_settings_are_float(self):
+        """タイムアウト設定がfloat型であること"""
+        s = Settings()
+        assert isinstance(s.openai_timeout, float)
+        assert isinstance(s.openai_connect_timeout, float)

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -105,7 +105,21 @@ class TestUploadValidation:
             data={"category": "その他", "industry_tags": ""},
         )
         assert response.status_code == 500
-        assert "処理エラー" in response.json()["detail"]
+        assert "ファイル処理中にエラーが発生しました" in response.json()["detail"]
+
+    @patch("app.api.documents.extract_text", side_effect=RuntimeError("secret internal error info"))
+    def test_error_detail_not_leaked(self, mock_extract):
+        """内部エラー詳細がレスポンスに含まれないことを検証"""
+        client = _create_client()
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("fail.txt", BytesIO(b"content"), "text/plain")},
+            data={"category": "その他", "industry_tags": ""},
+        )
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert "secret internal error info" not in detail
+        assert "ファイルの形式をご確認のうえ再度お試しください" in detail
 
 
 class TestListDocuments:

--- a/backend/tests/test_rag.py
+++ b/backend/tests/test_rag.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
-from app.core.rag import FORMAT_INSTRUCTIONS, generate_rag_response
+from app.core.rag import FORMAT_INSTRUCTIONS, _get_client, generate_rag_response
 from app.models.schemas import (
     CategoryType,
     ChatRequest,
@@ -373,3 +374,40 @@ class TestFormatInstructionsDict:
         assert "課題" in instruction
         assert "提案ポイント" in instruction
         assert "期待効果" in instruction
+
+
+class TestOpenAIClientTimeout:
+    """OpenAIクライアントのタイムアウト設定テスト"""
+
+    @patch("app.core.rag.OpenAI")
+    def test_client_created_with_timeout(self, mock_openai_cls):
+        """OpenAIクライアントがタイムアウト付きで生成される"""
+        import app.core.rag as rag_module
+        # シングルトンをリセット
+        rag_module._client = None
+
+        _get_client()
+
+        mock_openai_cls.assert_called_once()
+        call_kwargs = mock_openai_cls.call_args.kwargs
+        assert "timeout" in call_kwargs
+        timeout = call_kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+
+        # リセットして後続テストに影響を与えない
+        rag_module._client = None
+
+    @patch("app.core.rag.OpenAI")
+    def test_client_singleton_pattern(self, mock_openai_cls):
+        """_get_clientがシングルトンパターンで動作する"""
+        import app.core.rag as rag_module
+        rag_module._client = None
+
+        client1 = _get_client()
+        client2 = _get_client()
+
+        # OpenAIは1回だけ呼ばれる
+        mock_openai_cls.assert_called_once()
+        assert client1 is client2
+
+        rag_module._client = None


### PR DESCRIPTION
## 概要

内部エラー詳細のユーザー漏洩防止とOpenAI APIタイムアウト設定を追加します。

## 変更内容

### エラーメッセージのサニタイズ
- `backend/app/api/chat.py`: 例外の`str(e)`をレスポンスから除外し、汎用メッセージに変更
- `backend/app/api/documents.py`: 同様にエラー詳細をレスポンスから除外

### OpenAI APIタイムアウト設定
- `backend/app/core/config.py`: `openai_timeout`(30秒)と`openai_connect_timeout`(10秒)を追加
- `backend/app/core/rag.py`: OpenAIクライアント初期化時に`httpx.Timeout`でタイムアウトを設定

### テスト追加
- `test_chat_router.py`: チャットAPIエラーサニタイズのテスト（内部エラー詳細が漏洩しないことを検証）
- `test_documents_router.py`: ドキュメントAPIエラーサニタイズのテスト追加
- `test_config.py`: タイムアウト設定のデフォルト値テスト
- `test_rag.py`: OpenAIクライアントのタイムアウト設定テスト

## テスト結果

全72テストがパス。

Closes #19