### PR TITLE
fix: embeddings.pyのエラーハンドリング追加・テスト追加

### DIFF
--- a/backend/app/core/embeddings.py
+++ b/backend/app/core/embeddings.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from openai import OpenAI
+import httpx
+from openai import APIConnectionError, APITimeoutError, OpenAI, RateLimitError
 
 from app.core.config import settings
 
@@ -14,7 +15,10 @@ _client: OpenAI | None = None
 def _get_client() -> OpenAI:
     global _client
     if _client is None:
-        _client = OpenAI(api_key=settings.openai_api_key)
+        _client = OpenAI(
+            api_key=settings.openai_api_key,
+            timeout=httpx.Timeout(settings.openai_timeout, connect=settings.openai_connect_timeout),
+        )
     return _client
 
 
@@ -25,10 +29,20 @@ def generate_embeddings(texts: list[str]) -> list[list[float]]:
         return []
     logger.debug("Embedding生成開始: texts_count=%d, model=%s", len(texts), settings.openai_embedding_model)
     client = _get_client()
-    response = client.embeddings.create(
-        model=settings.openai_embedding_model,
-        input=texts,
-    )
+    try:
+        response = client.embeddings.create(
+            model=settings.openai_embedding_model,
+            input=texts,
+        )
+    except APITimeoutError:
+        logger.error("Embedding生成タイムアウト: texts_count=%d", len(texts))
+        raise
+    except RateLimitError:
+        logger.error("Embedding生成レート制限超過: texts_count=%d", len(texts))
+        raise
+    except APIConnectionError:
+        logger.error("Embedding生成接続エラー: texts_count=%d", len(texts))
+        raise
     logger.debug("Embedding生成完了: embeddings_count=%d", len(response.data))
     return [item.embedding for item in response.data]
 

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,0 +1,129 @@
+"""app/core/embeddings.py のユニットテスト"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from openai import APIConnectionError, APITimeoutError, RateLimitError  # noqa: E402
+
+
+class TestGenerateEmbeddings:
+    """generate_embeddings のテスト"""
+
+    def setup_method(self):
+        import app.core.embeddings as mod
+        mod._client = None
+
+    @patch("app.core.embeddings._get_client")
+    def test_returns_embeddings_for_valid_texts(self, mock_get_client):
+        """有効なテキストリストに対してEmbeddingリストを返す"""
+        from app.core.embeddings import generate_embeddings
+
+        mock_client = MagicMock()
+        mock_data = [MagicMock(embedding=[0.1, 0.2, 0.3]), MagicMock(embedding=[0.4, 0.5, 0.6])]
+        mock_client.embeddings.create.return_value = MagicMock(data=mock_data)
+        mock_get_client.return_value = mock_client
+
+        result = generate_embeddings(["テスト1", "テスト2"])
+
+        assert len(result) == 2
+        assert result[0] == [0.1, 0.2, 0.3]
+        assert result[1] == [0.4, 0.5, 0.6]
+        mock_client.embeddings.create.assert_called_once()
+
+    def test_empty_list_returns_empty(self):
+        """空のリストに対して空リストを返す"""
+        from app.core.embeddings import generate_embeddings
+
+        result = generate_embeddings([])
+        assert result == []
+
+    @patch("app.core.embeddings._get_client")
+    def test_api_timeout_raises_and_logs(self, mock_get_client):
+        """APIタイムアウト時に例外を再送出する"""
+        from app.core.embeddings import generate_embeddings
+
+        mock_client = MagicMock()
+        mock_client.embeddings.create.side_effect = APITimeoutError(request=MagicMock())
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(APITimeoutError):
+            generate_embeddings(["テスト"])
+
+    @patch("app.core.embeddings._get_client")
+    def test_rate_limit_raises_and_logs(self, mock_get_client):
+        """レート制限超過時に例外を再送出する"""
+        from app.core.embeddings import generate_embeddings
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {}
+        mock_client.embeddings.create.side_effect = RateLimitError(
+            message="rate limit",
+            response=mock_response,
+            body=None,
+        )
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(RateLimitError):
+            generate_embeddings(["テスト"])
+
+    @patch("app.core.embeddings._get_client")
+    def test_connection_error_raises_and_logs(self, mock_get_client):
+        """接続エラー時に例外を再送出する"""
+        from app.core.embeddings import generate_embeddings
+
+        mock_client = MagicMock()
+        mock_client.embeddings.create.side_effect = APIConnectionError(request=MagicMock())
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(APIConnectionError):
+            generate_embeddings(["テスト"])
+
+
+class TestGenerateEmbedding:
+    """generate_embedding のテスト"""
+
+    @patch("app.core.embeddings._get_client")
+    def test_returns_single_embedding(self, mock_get_client):
+        """単一テキストのEmbeddingを返す"""
+        from app.core.embeddings import generate_embedding
+
+        mock_client = MagicMock()
+        mock_data = [MagicMock(embedding=[0.1, 0.2, 0.3])]
+        mock_client.embeddings.create.return_value = MagicMock(data=mock_data)
+        mock_get_client.return_value = mock_client
+
+        result = generate_embedding("テスト")
+        assert result == [0.1, 0.2, 0.3]
+
+    def test_empty_text_raises_value_error(self):
+        """空テキストでValueErrorを送出する"""
+        from app.core.embeddings import generate_embedding
+
+        with pytest.raises(ValueError, match="空です"):
+            generate_embedding("   ")
+
+
+class TestEmbeddingClientTimeout:
+    """クライアントのタイムアウト設定テスト"""
+
+    def setup_method(self):
+        import app.core.embeddings as mod
+        mod._client = None
+
+    @patch("app.core.embeddings.OpenAI")
+    def test_client_has_timeout(self, mock_openai_cls):
+        """クライアントにタイムアウトが設定される"""
+        from app.core.embeddings import _get_client
+
+        _get_client()
+
+        mock_openai_cls.assert_called_once()
+        call_kwargs = mock_openai_cls.call_args[1]
+        assert "timeout" in call_kwargs


### PR DESCRIPTION
## 変更概要

- `embeddings.py` の `_get_client()` にタイムアウト設定を追加（rag.pyと統一）
- `generate_embeddings()` にOpenAI API固有の例外ハンドリングを追加（APITimeoutError, RateLimitError, APIConnectionError）
- `test_embeddings.py` を新設（8件のテスト: 正常系、空リスト、APIエラー3種、単一テキスト、空テキスト、タイムアウト設定確認）

Closes #21

## 動作確認手順
1. `cd backend && OPENAI_API_KEY="sk-dummy" python3 -m pytest tests/ -v` で全80テスト通過を確認