### PR TITLE
feat: ドキュメント一覧APIにページネーションを追加

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -121,14 +121,21 @@ async def upload_document(
 
 
 @router.get("/", response_model=DocumentListResponse)
-async def get_documents():
-    """登録済み資料一覧を取得"""
-    logger.debug("ドキュメント一覧取得リクエスト")
-    docs = list_documents()
-    logger.info("ドキュメント一覧取得: %d 件", len(docs))
+async def get_documents(offset: int = 0, limit: int = 20):
+    """登録済み資料一覧を取得（ページネーション対応）"""
+    if limit > 100:
+        limit = 100
+    if offset < 0:
+        offset = 0
+
+    logger.debug("ドキュメント一覧取得リクエスト: offset=%d, limit=%d", offset, limit)
+    docs, total = list_documents(offset=offset, limit=limit)
+    logger.info("ドキュメント一覧取得: %d/%d 件", len(docs), total)
     return DocumentListResponse(
         documents=[DocumentMetadata(**doc) for doc in docs],
-        total=len(docs),
+        total=total,
+        offset=offset,
+        limit=limit,
     )
 
 

--- a/backend/app/db/vector_store.py
+++ b/backend/app/db/vector_store.py
@@ -130,8 +130,10 @@ def delete_document(doc_id: str) -> None:
         logger.warning("ドキュメント削除: 対象チャンクが見つかりません。doc_id=%s", doc_id)
 
 
-def list_documents() -> list[dict]:
-    """登録済みドキュメント一覧を取得"""
+def list_documents(
+    offset: int = 0, limit: int = 20
+) -> tuple[list[dict], int]:
+    """登録済みドキュメント一覧を取得（ページネーション対応）"""
     collection = get_collection()
     all_data = collection.get(include=["metadatas"])
 
@@ -151,4 +153,11 @@ def list_documents() -> list[dict]:
             }
         doc_map[doc_id]["chunk_count"] += 1
 
-    return list(doc_map.values())
+    all_docs = sorted(
+        doc_map.values(),
+        key=lambda d: d.get("uploaded_at", ""),
+        reverse=True,
+    )
+    total = len(all_docs)
+    paginated = all_docs[offset:offset + limit]
+    return paginated, total

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -37,6 +37,8 @@ class DocumentUploadResponse(BaseModel):
 class DocumentListResponse(BaseModel):
     documents: list[DocumentMetadata]
     total: int
+    offset: int = 0
+    limit: int = 20
 
 
 class ChatRequest(BaseModel):

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -128,33 +128,71 @@ class TestListDocuments:
     @patch("app.api.documents.list_documents")
     def test_list_documents_empty(self, mock_list):
         """ドキュメントなしの場合に空リストを返す"""
-        mock_list.return_value = []
+        mock_list.return_value = ([], 0)
         client = _create_client()
         response = client.get("/api/documents/")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 0
         assert data["documents"] == []
+        assert data["offset"] == 0
+        assert data["limit"] == 20
 
     @patch("app.api.documents.list_documents")
     def test_list_documents_with_data(self, mock_list):
         """ドキュメントが存在する場合にリストを返す"""
-        mock_list.return_value = [
-            {
-                "id": "uuid-1",
-                "filename": "proposal.pdf",
-                "category": "提案書",
-                "industry_tags": ["製造業"],
-                "uploaded_at": "2026-01-01T00:00:00",
-                "chunk_count": 5,
-            },
-        ]
+        mock_list.return_value = (
+            [
+                {
+                    "id": "uuid-1",
+                    "filename": "proposal.pdf",
+                    "category": "提案書",
+                    "industry_tags": ["製造業"],
+                    "uploaded_at": "2026-01-01T00:00:00",
+                    "chunk_count": 5,
+                },
+            ],
+            1,
+        )
         client = _create_client()
         response = client.get("/api/documents/")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
         assert data["documents"][0]["filename"] == "proposal.pdf"
+
+    @patch("app.api.documents.list_documents")
+    def test_list_documents_with_pagination(self, mock_list):
+        """offset/limitパラメータが正しく渡される"""
+        mock_list.return_value = ([], 10)
+        client = _create_client()
+        response = client.get("/api/documents/?offset=5&limit=3")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["offset"] == 5
+        assert data["limit"] == 3
+        assert data["total"] == 10
+        mock_list.assert_called_once_with(offset=5, limit=3)
+
+    @patch("app.api.documents.list_documents")
+    def test_list_documents_limit_capped(self, mock_list):
+        """limitの上限は100"""
+        mock_list.return_value = ([], 0)
+        client = _create_client()
+        response = client.get("/api/documents/?limit=200")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["limit"] == 100
+
+    @patch("app.api.documents.list_documents")
+    def test_list_documents_negative_offset(self, mock_list):
+        """負のoffsetは0にクランプされる"""
+        mock_list.return_value = ([], 0)
+        client = _create_client()
+        response = client.get("/api/documents/?offset=-5")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["offset"] == 0
 
 
 class TestDeleteDocument:


### PR DESCRIPTION
## 変更概要

- `GET /api/documents/` に `offset` と `limit` クエリパラメータを追加
- `DocumentListResponse` に `offset`, `limit` フィールドを追加
- `list_documents` 関数がタプル `(list, total)` を返すように変更
- ドキュメントを `uploaded_at` 降順でソート
- `limit` 上限100、負の `offset` を0にクランプ
- テスト3件追加（ページネーション、limit上限、負offset）

Closes #23

## 動作確認手順

1. `cd backend && pytest tests/test_documents_router.py -v` で全テストがパスすることを確認
2. `curl http://localhost:8000/api/documents/?offset=0&limit=5` でページネーションが動作することを確認