### PR TITLE
refactor: MAX_FILE_SIZEの設定外部化

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -23,8 +23,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/documents", tags=["documents"])
 
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".doc", ".pptx", ".txt", ".md"}
-MAX_FILE_SIZE_MB = 50
-MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
 
 
 @router.post("/upload", response_model=DocumentUploadResponse)
@@ -52,10 +50,11 @@ async def upload_document(
     content = await file.read()
 
     # ファイルサイズチェック
-    if len(content) > MAX_FILE_SIZE_BYTES:
+    max_size_bytes = settings.max_file_size_mb * 1024 * 1024
+    if len(content) > max_size_bytes:
         raise HTTPException(
             status_code=400,
-            detail=f"ファイルサイズが上限 ({MAX_FILE_SIZE_MB}MB) を超えています",
+            detail=f"ファイルサイズが上限 ({settings.max_file_size_mb}MB) を超えています",
         )
 
     logger.info(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:3000"
     chroma_persist_dir: str = "./chroma_data"
     upload_dir: str = "./uploads"
+    max_file_size_mb: int = 50
     openai_timeout: float = 30.0
     openai_connect_timeout: float = 10.0
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -21,3 +21,23 @@ class TestTimeoutSettings:
         s = Settings()
         assert isinstance(s.openai_timeout, float)
         assert isinstance(s.openai_connect_timeout, float)
+
+
+class TestFileSizeSettings:
+    """ファイルサイズ設定のテスト"""
+
+    def test_default_max_file_size_mb(self):
+        """デフォルトのファイルサイズ上限が50MBであること"""
+        s = Settings()
+        assert s.max_file_size_mb == 50
+
+    def test_max_file_size_is_int(self):
+        """ファイルサイズ上限がint型であること"""
+        s = Settings()
+        assert isinstance(s.max_file_size_mb, int)
+
+    def test_max_file_size_env_override(self, monkeypatch):
+        """環境変数でファイルサイズ上限を変更できること"""
+        monkeypatch.setenv("MAX_FILE_SIZE_MB", "100")
+        s = Settings()
+        assert s.max_file_size_mb == 100


### PR DESCRIPTION
## 変更概要
- `app/core/config.py`: `max_file_size_mb: int = 50` をSettingsクラスに追加
- `app/api/documents.py`: ハードコードの `MAX_FILE_SIZE_MB` / `MAX_FILE_SIZE_BYTES` を削除し、`settings.max_file_size_mb` を参照するよう変更
- `tests/test_config.py`: MAX_FILE_SIZE設定のテスト3件を追加（デフォルト値・型・環境変数オーバーライド）

Closes #25

## 動作確認手順
1. `pytest tests/ -v` で全テストがパスすること
2. `MAX_FILE_SIZE_MB=100` を環境変数に設定し、ファイルサイズ上限が100MBに変更されること