### PR TITLE
fix: アップロードファイル名のサニタイズ処理を追加

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -2,8 +2,11 @@
 
 import logging
 import os
+import re
+import unicodedata
 import uuid
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
@@ -25,6 +28,17 @@ router = APIRouter(prefix="/api/documents", tags=["documents"])
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".doc", ".pptx", ".txt", ".md"}
 
 
+def sanitize_filename(filename: str) -> str:
+    """ファイル名から危険な文字やパス要素を除去する"""
+    filename = PurePosixPath(filename).name
+    filename = unicodedata.normalize("NFC", filename)
+    filename = re.sub(r'[\x00-\x1f<>:"/\\|?*]', "_", filename)
+    filename = filename.strip(". ")
+    if not filename:
+        filename = "unnamed"
+    return filename
+
+
 @router.post("/upload", response_model=DocumentUploadResponse)
 async def upload_document(
     file: UploadFile = File(...),
@@ -35,7 +49,10 @@ async def upload_document(
     if not file.filename:
         raise HTTPException(status_code=400, detail="ファイル名が必要です")
 
-    ext = os.path.splitext(file.filename)[1].lower()
+    safe_filename = sanitize_filename(file.filename)
+    logger.info("ファイル名サニタイズ: original=%s, sanitized=%s", file.filename, safe_filename)
+
+    ext = os.path.splitext(safe_filename)[1].lower()
     if ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(
             status_code=400,
@@ -59,7 +76,7 @@ async def upload_document(
 
     logger.info(
         "ファイルアップロード開始: filename=%s, size=%d bytes, category=%s",
-        file.filename,
+        safe_filename,
         len(content),
         category.value,
     )
@@ -86,7 +103,7 @@ async def upload_document(
         chunk_count = add_chunks(
             doc_id=doc_id,
             chunks=chunks,
-            filename=file.filename,
+            filename=safe_filename,
             category=category.value,
             industry_tags=tags,
             uploaded_at=uploaded_at,
@@ -95,14 +112,14 @@ async def upload_document(
         logger.info(
             "ファイルアップロード完了: doc_id=%s, filename=%s, chunk_count=%d",
             doc_id,
-            file.filename,
+            safe_filename,
             chunk_count,
         )
         return DocumentUploadResponse(
             id=doc_id,
-            filename=file.filename,
+            filename=safe_filename,
             chunk_count=chunk_count,
-            message=f"{file.filename} を {chunk_count} チャンクで登録しました",
+            message=f"{safe_filename} を {chunk_count} チャンクで登録しました",
         )
     except HTTPException:
         raise
@@ -112,7 +129,7 @@ async def upload_document(
             os.remove(file_path)
         logger.error(
             "ファイルアップロードエラー: filename=%s, error=%s",
-            file.filename,
+            safe_filename,
             str(e),
             exc_info=True,
         )

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -6,13 +6,44 @@ from unittest.mock import patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from app.api.documents import router
+from app.api.documents import router, sanitize_filename
 
 
 def _create_client() -> TestClient:
     app = FastAPI()
     app.include_router(router)
     return TestClient(app)
+
+
+class TestSanitizeFilename:
+    """ファイル名サニタイズのテスト"""
+
+    def test_normal_filename_unchanged(self):
+        assert sanitize_filename("report.pdf") == "report.pdf"
+
+    def test_japanese_filename_preserved(self):
+        assert sanitize_filename("提案書_v2.docx") == "提案書_v2.docx"
+
+    def test_path_traversal_removed(self):
+        assert sanitize_filename("../../../etc/passwd.txt") == "passwd.txt"
+
+    def test_backslash_path_replaced(self):
+        result = sanitize_filename("C:\\Users\\test\\doc.pdf")
+        assert "\\" not in result
+        assert result.endswith(".pdf")
+
+    def test_control_characters_replaced(self):
+        result = sanitize_filename("file\x00name\x1f.txt")
+        assert "\x00" not in result
+        assert "\x1f" not in result
+
+    def test_empty_after_strip_returns_unnamed(self):
+        assert sanitize_filename("...") == "unnamed"
+
+    def test_special_characters_replaced(self):
+        result = sanitize_filename('file<>:"|?*.txt')
+        assert "<" not in result
+        assert ">" not in result
 
 
 class TestUploadValidation:
@@ -106,6 +137,23 @@ class TestUploadValidation:
         )
         assert response.status_code == 500
         assert "ファイル処理中にエラーが発生しました" in response.json()["detail"]
+
+    @patch("app.api.documents.add_chunks", return_value=1)
+    @patch("app.api.documents.chunk_text", return_value=["chunk1"])
+    @patch("app.api.documents.extract_text", return_value="テスト本文")
+    def test_upload_sanitizes_filename(self, mock_extract, mock_chunk, mock_add):
+        """パストラバーサルを含むファイル名がサニタイズされる"""
+        client = _create_client()
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("../../evil.txt", BytesIO(b"content"), "text/plain")},
+            data={"category": "その他", "industry_tags": ""},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["filename"] == "evil.txt"
+        _, kwargs = mock_add.call_args
+        assert kwargs["filename"] == "evil.txt"
 
     @patch("app.api.documents.extract_text", side_effect=RuntimeError("secret internal error info"))
     def test_error_detail_not_leaked(self, mock_extract):


### PR DESCRIPTION
## 変更概要
- `sanitize_filename`関数を追加し、アップロードされたファイル名からパストラバーサル要素・制御文字・特殊文字を除去
- アップロードエンドポイントでサニタイズ済みファイル名をメタデータに保存するよう修正
- ファイル名サニタイズ��ユニッ���テスト7件 + 統合テスト1件を追加

Closes #29

## 動作確認
- `pytest tests/test_documents_router.py -v` 全22テストパス
- `pytest tests/ -v` 全108テスト中、pptxモジュール未インストールのtest_pptx_file以外パス（既存の問題）